### PR TITLE
fix(partial) use local port and no host header, fixes #3

### DIFF
--- a/commands/host/share-cf
+++ b/commands/host/share-cf
@@ -113,22 +113,19 @@ if ! command -v cloudflared &> /dev/null; then
     exit 1
 fi
 
-# Get DDEV site URL and hostname
-DDEV_PRIMARY_URL=$(ddev describe -j | grep -o '"primary_url":"[^"]*' | cut -d'"' -f4)
-DDEV_HOSTNAME=$(ddev describe -j | grep -o '"hostname":"[^"]*' | head -1 | cut -d'"' -f4)
-
-if [ -z "$DDEV_PRIMARY_URL" ]; then
-    echo -e "${RED}❌ Could not determine DDEV site URL${NC}"
+if [ -z "$DDEV_HOST_HTTP_PORT" ]; then
+    echo -e "${RED}❌ Could not determine DDEV local port URL${NC}"
     echo -e "${YELLOW}Make sure you're in a DDEV project directory and the project is running${NC}"
     exit 1
 fi
 
 echo -e "${GREEN}✅ cloudflared is installed${NC}"
 echo ""
+DDEV_LOCALHOST_URL="http://127.0.0.1:${DDEV_HOST_HTTP_PORT}"
 echo -e "${BLUE}🚀 Starting Cloudflare Tunnel...${NC}"
 echo -e "${YELLOW}⏳ Generating public URL (this may take a few seconds)...${NC}"
 echo ""
-echo -e "${CYAN}📍 Local site: ${DDEV_PRIMARY_URL}${NC}"
+echo -e "${CYAN}📍 Local site: ${DDEV_LOCALHOST_URL}${NC}"
 echo ""
 echo -e "${YELLOW}💡 Tip: Press Ctrl+C to stop the tunnel${NC}"
 
@@ -150,4 +147,4 @@ echo ""
 
 # Start the tunnel pointing to the DDEV site with proper host header
 # The tunnel URL will be printed to the console by cloudflared
-cloudflared tunnel --url "$DDEV_PRIMARY_URL" --http-host-header "$DDEV_HOSTNAME"
+cloudflared tunnel --url "${DDEV_LOCALHOST_URL}"


### PR DESCRIPTION
## Description


Fixes #3

This fixes #3 but won't help with multisite, which is a larger problem and requires more effort. 

As described in https://stackoverflow.com/questions/78729503/drupal-10-multisite-using-ddev-share-or-cloudflare you would have to configure sites.php for the given URL for this to work with multisite.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

Tried out the  problem shown in #3 


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
