### PR TITLE
docs: improve WSL2 documentation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ This DDEV addon provides a simple command to share your local DDEV sites publicl
 
 - DDEV v1.21.0 or higher
 - `cloudflared` binary installed on your host machine
-- macOS, Linux, or Windows/WSL2
+- macOS, Linux, or Windows with WSL2
+
+**Important for Windows users:** This addon requires WSL2. You must install and run DDEV in WSL2, not natively on Windows. See the [WSL2 section](#windows-with-wsl2) below for details.
 
 ## Installation
 
@@ -48,10 +50,19 @@ curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloud
 sudo rpm -i cloudflared.rpm
 ```
 
-**Windows:**
-```powershell
-winget install --id Cloudflare.cloudflared
+**Windows with WSL2:**
+
+> **Important:** This addon requires WSL2. WSL2 is your "host" environment where both DDEV and cloudflared must be installed.
+
+If you're using DDEV with WSL2 (the recommended approach for Windows), follow the Linux instructions above **inside your WSL2 terminal**. For example, if using Ubuntu in WSL2:
+
+```bash
+# Run this inside your WSL2 terminal (not PowerShell or CMD)
+curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+sudo dpkg -i cloudflared.deb
 ```
+
+**Do NOT install cloudflared on Windows itself** - it needs to be installed in WSL2 where DDEV runs.
 
 For other installation methods, see the [Cloudflare documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/).
 
@@ -108,7 +119,21 @@ Perfect for:
 
 ## Troubleshooting
 
-### cloudflared not found
+### Windows/WSL2: cloudflared not found
+
+If you're using Windows with WSL2 and getting a "cloudflared not found" error:
+
+1. **Verify you're in WSL2**: Open your WSL2 terminal (Ubuntu, Debian, etc.) - not PowerShell or CMD
+2. **Install cloudflared in WSL2**: Follow the Linux installation instructions in your WSL2 terminal:
+   ```bash
+   curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+   sudo dpkg -i cloudflared.deb
+   ```
+3. **Run all DDEV commands in WSL2**: Both `ddev` and `ddev share-cf` must be run from your WSL2 terminal
+
+**Common mistake:** Installing cloudflared on Windows (via winget or PowerShell) instead of in WSL2. Remember: WSL2 is your "host" environment, not Windows.
+
+### cloudflared not found (macOS/Linux)
 
 If you get an error that `cloudflared` is not installed, the command will automatically detect your operating system and show you the appropriate installation instructions.
 

--- a/commands/host/share-cf
+++ b/commands/host/share-cf
@@ -21,6 +21,12 @@ detect_system() {
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
 
+    # Check if running in WSL
+    IS_WSL=false
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+        IS_WSL=true
+    fi
+
     case "$OS" in
         linux*)
             OS_TYPE="linux"
@@ -76,6 +82,10 @@ show_install_instructions() {
             echo -e "  ${BLUE}sudo chmod +x /usr/local/bin/cloudflared${NC}"
             ;;
         linux)
+            if [ "$IS_WSL" = true ]; then
+                echo -e "${CYAN}✅ WSL2 detected - Install cloudflared in WSL2:${NC}"
+                echo ""
+            fi
             echo -e "${CYAN}Debian/Ubuntu:${NC}"
             echo -e "  ${BLUE}curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${ARCH_TYPE}.deb -o cloudflared.deb${NC}"
             echo -e "  ${BLUE}sudo dpkg -i cloudflared.deb${NC}"
@@ -90,10 +100,13 @@ show_install_instructions() {
             echo -e "  ${BLUE}sudo chmod +x /usr/local/bin/cloudflared${NC}"
             ;;
         windows)
-            echo -e "${CYAN}Windows:${NC}"
-            echo -e "  ${BLUE}Download from: https://github.com/cloudflare/cloudflared/releases/latest${NC}"
-            echo -e "  ${BLUE}Or use winget: winget install --id Cloudflare.cloudflared${NC}"
-            echo -e "  ${BLUE}Or use Chocolatey: choco install cloudflared${NC}"
+            echo -e "${CYAN}Windows (WSL2):${NC}"
+            echo -e "  ${YELLOW}⚠️  Note: This addon requires WSL2. You must install cloudflared in WSL2, not on Windows.${NC}"
+            echo -e "  ${BLUE}If you see this message, you're likely running from Windows instead of WSL2.${NC}"
+            echo ""
+            echo -e "${CYAN}Install cloudflared in WSL2 (run in WSL2 terminal):${NC}"
+            echo -e "  ${BLUE}curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${ARCH_TYPE}.deb -o cloudflared.deb${NC}"
+            echo -e "  ${BLUE}sudo dpkg -i cloudflared.deb${NC}"
             ;;
         *)
             echo -e "${CYAN}Unknown OS - Manual Installation:${NC}"


### PR DESCRIPTION
## Description
- Add dedicated WSL2 section to README with clear installation steps
- Update requirements section to emphasize WSL2 for Windows users
- Add WSL2-specific troubleshooting guide
- Improve script error messages to detect and guide WSL2 users
- Clarify that WSL2 is the "host" environment, not Windows
- Remove confusing Windows-native installation methods (winget)

Fixes #7

## Type of change
- [ X] Documentation update

## Checklist:
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ]X I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ X] New and existing tests pass locally with my changes


**To test:**

  1. In your WSL2 terminal (Ubuntu, Debian, etc.), install cloudflared:
     ```bash
     curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
     sudo dpkg -i cloudflared.deb

  2. Install the addon from this branch:
  ddev add-on get davo20019/ddev-share-cf#7-windows-wsl-documentation
  3. Try running:
  ddev share-cf

