### PR TITLE
fix: recommend wp search-replace for WordPress tunnel URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,28 +183,26 @@ $sites['random-name.trycloudflare.com'] = 'stage';  // Replace 'stage' with your
 
 ### WordPress URL Redirects
 
-The addon **automatically detects** WordPress installations. WordPress stores site URLs in the database, which can cause redirects (like after login) to redirect back to your local domain instead of staying on the tunnel URL.
+The addon **automatically detects** WordPress installations. WordPress stores absolute URLs throughout the database (options, post content, meta fields, serialized data, etc.), which causes redirects, broken media, and broken links when accessing the site through a tunnel URL.
 
-When WordPress is detected, the addon will display instructions. To fix redirects:
+When WordPress is detected, the addon will display instructions. To fix this, use `wp search-replace` to replace URLs across all tables (including serialized data):
 
 1. Run `ddev share-cf` and note the generated URL (e.g., `https://random-name.trycloudflare.com`)
-2. Update WordPress URLs using WP-CLI:
+2. Replace all URLs in the database:
 
 ```bash
-# Update to tunnel URL
-ddev wp option update home 'https://random-name.trycloudflare.com'
-ddev wp option update siteurl 'https://random-name.trycloudflare.com'
+# Replace local URL with tunnel URL (handles serialized data correctly)
+ddev wp search-replace 'https://yoursite.ddev.site' 'https://random-name.trycloudflare.com' --all-tables
 ```
 
 3. When done, revert back to local URLs:
 
 ```bash
 # Revert to local domain
-ddev wp option update home 'https://yoursite.ddev.site'
-ddev wp option update siteurl 'https://yoursite.ddev.site'
+ddev wp search-replace 'https://random-name.trycloudflare.com' 'https://yoursite.ddev.site' --all-tables
 ```
 
-**Note:** The tunnel URL changes each time you run the command, so you'll need to update the URLs for each session. Alternatively, consider using the [Relative URL](https://wordpress.org/plugins/relative-url/) plugin for easier multi-domain support.
+**Note:** The tunnel URL changes each time you run the command, so you'll need to repeat this for each session.
 
 ### Magento Base URL Redirects
 

--- a/commands/host/share-cf
+++ b/commands/host/share-cf
@@ -176,10 +176,9 @@ fi
 
 if [ "$WORDPRESS_DETECTED" = true ]; then
     echo -e "${CYAN}ℹ️  WordPress detected${NC}"
-    echo -e "${YELLOW}⚠️  Note: WordPress redirects may use the local domain instead of tunnel URL${NC}"
-    echo -e "${YELLOW}   To fix, update URLs after tunnel starts:${NC}"
-    echo -e "${YELLOW}   ddev wp option update home 'https://your-tunnel-url.trycloudflare.com'${NC}"
-    echo -e "${YELLOW}   ddev wp option update siteurl 'https://your-tunnel-url.trycloudflare.com'${NC}"
+    echo -e "${YELLOW}⚠️  Note: WordPress stores absolute URLs in the database. To fix, replace them after tunnel starts:${NC}"
+    echo -e "${YELLOW}   ddev wp search-replace 'https://${DDEV_FIRST_HOSTNAME}' 'https://your-tunnel-url.trycloudflare.com' --all-tables${NC}"
+    echo -e "${YELLOW}   To revert: ddev wp search-replace 'https://your-tunnel-url.trycloudflare.com' 'https://${DDEV_FIRST_HOSTNAME}' --all-tables${NC}"
 fi
 
 if [ "$MAGENTO_DETECTED" = true ]; then


### PR DESCRIPTION
## Summary

- Replace `wp option update home/siteurl` instructions with `wp search-replace --all-tables`, which handles absolute URLs across the entire database including serialized data
- Point users toward named tunnels so the search-replace only needs to happen once

Closes #14

## Test plan

- [ ] Verify README WordPress section recommends `ddev wp search-replace` with `--all-tables`
- [ ] Verify revert instructions also use `wp search-replace`
- [ ] Verify named tunnels link works